### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix a typo

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,10 @@ preview = true
 [tool.ruff.lint]
 ignore = ["E203", "E221", "E241", "E251"]
 select = ["E", "F", "I", "N", "RUF", "UP", "W"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+# ignore-regex = ''
+ignore-words-list = 'datas'

--- a/src/mni_7t_dicom_to_bids/dataclass.py
+++ b/src/mni_7t_dicom_to_bids/dataclass.py
@@ -206,7 +206,7 @@ class BidsName:
 
     def get(self, label: str) -> str | None:
         """
-        Get the value associated with a lavel in the BIDS name.
+        Get the value associated with a label in the BIDS name.
         """
 
         return self.entries[label]


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

congrats -- just 1 typo! feel free to ignore