### PR TITLE
Add MT flip angle to JSON.

### DIFF
--- a/src/mni_7t_dicom_to_bids/convert_dicom_series.py
+++ b/src/mni_7t_dicom_to_bids/convert_dicom_series.py
@@ -63,6 +63,7 @@ def convert_dicom_series(bids_session: BidsSessionInfo, dicom_bids_mapping: Dico
                 bids_data_type_path,
                 counter,
                 lambda tmp_dicom_dir_path, tmp_output_path: convert_bids_dicom_series(
+                    dicom_series,
                     bids_session,
                     bids_acquisition,
                     bids_data_type_path,
@@ -114,6 +115,7 @@ def get_conversions_counter(dicom_bids_mapping: DicomBidsMapping, args: Args) ->
 
 
 def convert_bids_dicom_series(
+    dicom_series: DicomSeriesInfo,
     bids_session: BidsSessionInfo,
     bids_acquisition: BidsAcquisitionInfo,
     bids_data_type_path: str,
@@ -130,7 +132,7 @@ def convert_bids_dicom_series(
 
     run_dicom_to_niix(tmp_dicom_dir_path, tmp_output_dir_path, file_name, args)
 
-    patch_files(Path(tmp_output_dir_path))
+    patch_files(Path(tmp_output_dir_path), dicom_series)
 
     # Check if the files already exist in the target directory.
 


### PR DESCRIPTION
Extracted and reworked from #8

List of changes compared to the original PR:
- The attribute name for the MT flip angle has been renamed from `mtFlip_Angle` to `MTFlipAngle` to better match the BIDS naming conventions like `MTState` (see [documentation](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html)).
- Look for the MT flip angle in the Siemens CSA header DICOM attribute instead lof the whole file.
- Write the MT flip angle as a number instead of a string like other MRI parameters in the BIDS JSON sidecar.
- Do not write the `MTFlipAngle` attribute if no MT flip angle is present (instead of writing `"None"`).
- Move the JSON patching of the MT flip angle has been moved from `convert_dicom_series` to `patch_files.py` file with the other JSON patchings.