### PR TITLE
Add `dcm2niix` and BIDS validator versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 FROM python:3.11-slim
 
 # Install the installation dependencies.
-RUN apt-get update && apt-get install -y curl git unzip
-
-# Install the latest version of `dcm2niix`.
-RUN curl -fLO https://github.com/rordenlab/dcm2niix/releases/latest/download/dcm2niix_lnx.zip
-RUN unzip dcm2niix_lnx.zip -d /usr/bin
+RUN apt-get update && apt-get install -y git
 
 # Copy the project directory.
 COPY . /mni_7t_dicom_to_bids

--- a/README.md
+++ b/README.md
@@ -48,7 +48,21 @@ Finally, you can also install the converter as a Python package. To do so, run t
 pip install git+https://github.com/bic-mni/mni-7t-dicom-to-bids
 ```
 
-Note that you must also have [dcm2niix](https://github.com/rordenlab/dcm2niix) (preferably a more recent version) installed on your machine.
+This command also installs the recommended version of [dcm2niix](https://github.com/rordenlab/dcm2niix).
+
+To also the recommended version of the BIDS validator, use the `validator` extra:
+
+```sh
+pip install "mni_7t_dicom_to_bids[validator] @ git+https://github.com/bic-mni/mni-7t-dicom-to-bids"
+```
+
+## Target software version
+
+| **Software**       | **Version**     |
+|--------------------|-----------------|
+| BIDS Specification | `v1.11.1`       |
+| BIDS Validator     | `v2.4.1`        |
+| dcm2niix           | `v1.0.20260416` |
 
 ## BIDS naming dictionary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license-files = ["LICENSE"]
 requires-python = ">= 3.11"
 dependencies = [
     "bic_util @ git+https://github.com/bic-mni/bic-mri-pipeline-util",
+    "dcm2niix==1.0.20260416",
     "pydicom",
 ]
 
@@ -20,6 +21,9 @@ dev = [
     "pyright",
     "ruff",
     "typos",
+]
+validator = [
+    "bids-validator-deno==2.4.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Partially addresses #15

- Pin the version of `dcm2niix` to `v1.0.20260416` by adding it as a Python dependency.
- Add an optional dependency on the BIDS validator to version `v2.4.1`.
