### PR TITLE
Improve `participants.tsv` file handling

### DIFF
--- a/src/mni_7t_dicom_to_bids/dataset_files.py
+++ b/src/mni_7t_dicom_to_bids/dataset_files.py
@@ -23,8 +23,6 @@ def add_dataset_files(bids_dataset_path: Path, bids_session: BidsSessionInfo, di
 
     add_participants_7t_to_bids_json_file(bids_dataset_path, bids_session, dicom_study_path)
 
-    add_participants_tsv_file(bids_dataset_path, bids_session)
-
     add_sessions_tsv_file(bids_dataset_path, bids_session)
 
 
@@ -92,25 +90,6 @@ def add_participants_7t_to_bids_json_file(
             f"{bids_session.subject}\t{bids_session.session}\t{date_string}\t"
             f"{anat_count}\t{dwi_count}\t{func_count}\t{fmap_count}\t{dicom_study_path}\t{getpass.getuser()}\n"
         )
-
-
-def add_participants_tsv_file(bids_dataset_path: Path, bids_session: BidsSessionInfo):
-    """
-    Create or update the `participants.tsv` BIDS file.
-    """
-
-    file_path = bids_dataset_path / 'participants.tsv'
-    if file_path.exists():
-        print("File 'participants.tsv' already exists.")
-    else:
-        print("Creating file 'participants.tsv'...")
-        with file_path.open('w') as file:
-            file.write("participant_id\tsite\n")
-
-    print("Appending session to file 'participants.tsv'...")
-
-    with file_path.open('a') as file:
-        file.write(f"sub-{bids_session.subject}\tMontreal_SiemmensTerra7T\n")
 
 
 def add_sessions_tsv_file(bids_dataset_path: Path, bids_session: BidsSessionInfo):

--- a/src/mni_7t_dicom_to_bids/metadata/participants.py
+++ b/src/mni_7t_dicom_to_bids/metadata/participants.py
@@ -1,0 +1,53 @@
+import csv
+from pathlib import Path
+from typing import cast
+
+from bic_util.util import find
+
+
+class ParticipantsTsvError(ValueError):
+    """
+    Error raised when `participants.tsv` cannot be safely updated.
+    """
+
+
+def update_participants_tsv(bids_dataset_path: Path, subject: str):
+    """
+    Create or update `participants.tsv` with one row for the converted subject.
+
+    Preserve existing columns and rows. Use `n/a` for values of existing columns that are unknown
+    for a newly added participant.
+    """
+
+    file_path = bids_dataset_path / 'participants.tsv'
+    participant_id = f'sub-{subject}'
+
+    if file_path.exists():
+        print("File 'participants.tsv' already exists.")
+        with file_path.open(encoding='utf-8', newline='') as file:
+            reader = csv.DictReader(file, delimiter='\t')
+            columns = reader.fieldnames
+            participants = [cast(dict[str, str], participant) for participant in reader]
+    else:
+        print("Creating file 'participants.tsv'...")
+        columns = ['participant_id']
+        participants: list[dict[str, str]] = []
+
+    if columns is None or columns[0] != 'participant_id':
+        raise ParticipantsTsvError(f"Expected the first column of '{file_path}' to be 'participant_id'.")
+
+    participant = find(lambda participant: participant['participant_id'] == participant_id, participants)
+    if participant is not None:
+        print(f"Participant '{participant_id}' already exists in 'participants.tsv'. Skipping.")
+        return
+
+    print(f"Adding participant '{participant_id}' to 'participants.tsv'...")
+    participants.append({
+        column: participant_id if column == 'participant_id' else 'n/a'
+        for column in columns
+    })
+
+    with file_path.open('w', encoding='utf-8', newline='') as file:
+        writer = csv.DictWriter(file, fieldnames=columns, delimiter='\t', lineterminator='\n')
+        writer.writeheader()
+        writer.writerows(participants)

--- a/src/mni_7t_dicom_to_bids/pipeline.py
+++ b/src/mni_7t_dicom_to_bids/pipeline.py
@@ -5,6 +5,7 @@ from mni_7t_dicom_to_bids.dataset_files import add_dataset_files
 from mni_7t_dicom_to_bids.group_dicom_series import group_dicom_series
 from mni_7t_dicom_to_bids.map_dicom_series import map_bids_dicom_series
 from mni_7t_dicom_to_bids.metadata.dataset_description import patch_dataset_description
+from mni_7t_dicom_to_bids.metadata.participants import update_participants_tsv
 from mni_7t_dicom_to_bids.print import (
     print_found_dicom_series,
     print_found_ignored_dicom_series,
@@ -37,6 +38,8 @@ def mni_7t_dicom_to_bids(args: Args):
     )
 
     convert_dicom_series(bids_session, dicom_bids_mapping, args)
+
+    update_participants_tsv(args.bids_dataset_path, args.subject)
 
     if args.dataset_files:
         add_dataset_files(args.bids_dataset_path, bids_session, args.dicom_study_path, args.overwrite)


### PR DESCRIPTION
Partially addresses #15

- Add an entry in `participants.tsv` even if the `--dataset-files` option is not used.
- Fix a bug where a duplicate participant could be added (whoopsie, I thought I had already fixed it).