### PR TITLE
Update dictionary and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ pip install "mni_7t_dicom_to_bids[validator] @ git+https://github.com/bic-mni/mn
 |   11  |  anat-flair_acq-0p7iso_UPAdia                      | FLAIR                                 | anat          |
 
 ### Anatomical: MEGRE
-
+| **N** | **7T Terra Siemens acquisition**    | **BIDS**                  | **Directory** |
+|:-----:|:-----------------------------------:|:-------------------------:|:-------------:|
 |  12   |  CLEAR-SWI_anat-T2star_acq-me_gre_0\*7iso_ASPIRE    | acq-megre07_rec-CLEARSWI_T2starw                      | anat          |
 |  13   |  Aspire_M_anat-T2star_acq-me_gre_0\*7iso_ASPIRE     | acq-megre07_rec-ASPIRE_echo-[1:5]_part-mag_MEGRE      | anat          |
 |  14   |  Aspire_P_anat-T2star_acq-me_gre_0\*7iso_ASPIRE     | acq-megre07_rec-ASPIRE_echo-[1:5]_part-phase_MEGRE    | anat          |
@@ -96,7 +97,8 @@ pip install "mni_7t_dicom_to_bids[validator] @ git+https://github.com/bic-mni/mn
 
 
 ### Anatomical: Magnetic Transfer weighted, Neuromelanin and time of flight
-
+| **N** | **7T Terra Siemens acquisition**    | **BIDS**                  | **Directory** |
+|:-----:|:-----------------------------------:|:-------------------------:|:-------------:|
 |  21   |  anat-mtw_acq-MTON_07mm                            | acq-mtw_mt-on_MTR                   | anat          |
 |  22   |  anat-mtw_acq-MTOFF_07mm                           | acq-mtw_mt-off_MTR                  | anat          |
 |  23   |  anat-mtw_acq-T1w_07mm                             | acq-mtw_T1w                         | anat          |

--- a/README.md
+++ b/README.md
@@ -66,36 +66,45 @@ pip install "mni_7t_dicom_to_bids[validator] @ git+https://github.com/bic-mni/mn
 
 ## BIDS naming dictionary
 
-### Anatomical
+### Anatomical: MPRAGE, MP2RAGE and FLAIR
 
-| **N** | **7T Terra Siemens acquisition**                   | **BIDS**                            | **Directory** |
-|:-----:|:--------------------------------------------------:|:-----------------------------------:|:-------------:|
-|   1   |  anat-T1w_acq_mprage_0.8mm_CSptx                   | T1w                                 | anat          |
-|   2   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_INV1             | acq-07mm_inv-1_MP2RAGE              | anat          |
-|   3   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_INV2             | acq-07mm_inv-2_MP2RAGE              | anat          |
-|   4   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_T1_Images        | acq-07mm_T1map                      | anat          |
-|   5   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_UNI_Images       | acq-07mm_UNIT1                      | anat          |
-|   6   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_UNI-DEN          | desc-denoised_UNIT1                 | anat          |
-|   7   |  anat-flair_acq-0p7iso_UPAdia                      | FLAIR                               | anat          |
-|   8   |  CLEAR-SWI_anat-T2star_acq-me_gre_0\*7iso_ASPIRE   | acq-SWI_T2starw                     | anat          |
-|   9   |  Romeo_P_anat-T2star_acq-me_gre_0\*7iso_ASPIRE     | acq-romeo_T2starw                   | anat          |
-|  10   |  Romeo_Mask_anat-T2star_acq-me_gre_0\*7iso_ASPIRE  | acq-romeo_rec-mask_T2starw          | anat          |
-|  11   |  Romeo_B0_anat-T2star_acq-me_gre_0\*7iso_ASPIRE    | acq-romeo_rec-unwrapped_T2starw     | anat          |
-|  12   |  Aspire_M_anat-T2star_acq-me_gre_0\*7iso_ASPIRE    | acq-aspire_part-mag_T2starw         | anat          |
-|  13   |  Aspire_P_anat-T2star_acq-me_gre_0\*7iso_ASPIRE    | acq-aspire_part-phase_T2starw       | anat          |
-|  14   |  EchoCombined_anat-T2star_acq-me_gre_0\*7iso_ASPIRE | acq-aspire_rec-echoCombined_T2starw | anat          |
-|  15   |  sensitivity_corrected_mag_anat-T2star_acq-me_gre_0\*7iso_ASPIRE | acq-aspire_rec-echoCombinedSensitivityCorrected_T2starw | anat |
-|  16   |  T2star_anat-T2star_acq-me_gre_0\*7iso_ASPIRE      | acq-aspire_[T2starw,T2starmap]      | anat          |
-|  17   |  anat-mtw_acq-MTON_07mm                            | acq-mtw_mt-on_MTR                   | anat          |
-|  18   |  anat-mtw_acq-MTOFF_07mm                           | acq-mtw_mt-off_MTR                  | anat          |
-|  19   |  anat-mtw_acq-T1w_07mm                             | acq-mtw_T1w                         | anat          |
-|  20   |  anat-nm_acq-MTboost_sag_0.55mm                    | acq-neuromelaninMTw_T1w             | anat          |
-|  21   |  anat-angio_acq-tof_03mm_inplane                   | angio                               | anat          |
-|  22   |  anat-angio_acq-tof_03mm_inplane_MIP_SAG           | acq-sag_angio                       | anat          |
-|  23   |  anat-angio_acq-tof_03mm_inplane_MIP_COR           | acq-cor_angio                       | anat          |
-|  24   |  anat-angio_acq-tof_03mm_inplane_MIP_TRA           | acq-tra_angio                       | anat          |
+| **N** | **7T Terra Siemens acquisition**                   | **BIDS**                              | **Directory** |
+|:-----:|:--------------------------------------------------:|:-------------------------------------:|:-------------:|
+|   1   |  anat-T1w_acq_mprage_0.8mm_CSptx                   | acq-mprage08CS_T1w                    | anat          |
+|   2   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_INV1             | acq-mp2rage07CSptx_inv-1_MP2RAGE      | anat          |
+|   3   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_INV2             | acq-mp2rage07CSptx_inv-2_MP2RAGE      | anat          |
+|   4   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_T1_Images        | acq-mp2rage07CSptx_T1map              | anat          |
+|   5   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_UNI_Images       | acq-mp2rage07CSptx_UNIT1              | anat          |
+|   6   |  anat-T1w_acq-mp2rage_0.7mm_CSptx_UNI-DEN          | acq-mp2rage07CSptx_rec-denoised_UNIT1 | anat          |
+|   7   |  anat-T1w_acq-mp2rage_05mm_UP*_INV1	             | acq-mp2rage05UP_inv-1_MP2RAGE         | anat          |
+|   8   |  anat-T1w_acq-mp2rage_05mm_UP*_INV2	             | acq-mp2rage05UP_inv-2_MP2RAGE         | anat          |
+|   9   |  anat-T1w_acq-mp2rage_05mm_UP*_T1_Images	         | acq-mp2rage05UP_T1map                 | anat          |
+|   10  |  anat-T1w_acq-mp2rage_05mm_UP*_UNI_Images	         | acq-mp2rage05UP_UNIT1                 | anat          |
+|   11  |  anat-flair_acq-0p7iso_UPAdia                      | FLAIR                                 | anat          |
 
-> The acquisitions `acq-romeo_part-phase_T2starw`, `acq-aspire_part-mag_T2starw`, and `acq-aspire_part-phase_T2starw` each have five echoes. The final string will include the identifier `echo-` followed by the echo number. For example: `acq-aspire_echo-1_part-mag_T2starw`.
+### Anatomical: MEGRE
+
+|  12   |  CLEAR-SWI_anat-T2star_acq-me_gre_0\*7iso_ASPIRE    | acq-megre07_rec-CLEARSWI_T2starw                      | anat          |
+|  13   |  Aspire_M_anat-T2star_acq-me_gre_0\*7iso_ASPIRE     | acq-megre07_rec-ASPIRE_echo-[1:5]_part-mag_MEGRE      | anat          |
+|  14   |  Aspire_P_anat-T2star_acq-me_gre_0\*7iso_ASPIRE     | acq-megre07_rec-ASPIRE_echo-[1:5]_part-phase_MEGRE    | anat          |
+|  15   |  EchoCombined_anat-T2star_acq-me_gre_0\*7iso_ASPIRE | acq-megre07_rec-ASPIRE_desc-EchoCombined_T2starw      | anat          |
+|  16   |  sensitivity_corrected_mag_anat-T2star_acq-me_gre_0\*7iso_ASPIRE | acq-megre07_rec-ASPIRE_desc-EchoCombinedSensCorr_T2starw | anat |
+|  17   |  T2star_anat-T2star_acq-me_gre_0\*7iso_ASPIRE       | acq-megre07_rec-ASPIRE_[T2starw,T2starmap]                            | anat |
+|  18   |  Romeo_P_anat-T2star_acq-me_gre_0\*7iso_ASPIRE      | acq-megre07_rec-ROMEO_echo-[1:5]_T2starw              | anat          |
+|  19   |  Romeo_B0_anat-T2star_acq-me_gre_0\*7iso_ASPIRE     | acq-megre07_rec-ROMEO_desc-unwrapped_T2starw          | anat          |
+|  20   |  Romeo_Mask_anat-T2star_acq-me_gre_0\*7iso_ASPIRE   | acq-megre07_rec-ROMEO_desc-mask_T2starw               | anat          |
+
+
+### Anatomical: Magnetic Transfer weighted, Neuromelanin and time of flight
+
+|  21   |  anat-mtw_acq-MTON_07mm                            | acq-mtw_mt-on_MTR                   | anat          |
+|  22   |  anat-mtw_acq-MTOFF_07mm                           | acq-mtw_mt-off_MTR                  | anat          |
+|  23   |  anat-mtw_acq-T1w_07mm                             | acq-mtw_T1w                         | anat          |
+|  24   |  anat-nm_acq-MTboost_sag_0.55mm                    | acq-neuromelaninMTw_T1w             | anat          |
+|  25   |  anat-angio_acq-tof_03mm_inplane                   | acq-tof_angio                       | anat          |
+|  26   |  anat-angio_acq-tof_03mm_inplane_MIP_SAG           | acq-tof_rec-mipsag_angio            | anat          |
+|  27   |  anat-angio_acq-tof_03mm_inplane_MIP_COR           | acq-tof_rec-mipcor_angio            | anat          |
+|  28   |  anat-angio_acq-tof_03mm_inplane_MIP_TRA           | acq-tof_rec-miptra_angio            | anat          |
 
 ### Field maps
 
@@ -135,13 +144,21 @@ pip install "mni_7t_dicom_to_bids[validator] @ git+https://github.com/bic-mni/mn
 |------------------|---------------------------------------------------------------|
 | **AP**           | Anterio-Posterior                                             |
 | **PA**           | Postero-anterior                                              |
-| **mtw**          | Magnetic transfer weighted                                    |
+| **CS**           | Compressed SENSE                                              |
+| **ptx**          | Parallel transmission                                         |
+| **UP**           | Universal Pulse                                               |
+| **megre**        | Multi-Echo Gradient Echo.                                     |
+| **mip**          | Maximum intensity projection                                  |
+| **cor**          | Coronal                                                       |
+| **sag**          | Sagittal                                                      |
+| **tra**          | Transverse (Axial)                                            |
+| **mtw**          | Magnetization Transfer Weighted                               |
 | **sfmap**        | Scaled flip angle map                                         |
-| **tof**          | Time of flight                                                |
-| **multib**       | Multi shell N directions                                      |
+| **tof**          | Time-of-flight                                                |
+| **multib**       | Multi shell DWI                                               |
 | **semphon**      | Semantic-phonetic                                             |
-| **romeo**        | Rapid opensource minimum spanning tree algorithm              |
-| **aspire**       | Combination of multi-channel phase data from multi-echo acquisitions |
+| **ASPIRE**       | Combination of multi-channel phase data from multi-echo acquisitions |
+| **ROMEO**        | Rapid opensource minimum spanning tree algorithm              |
 
 ### References
 

--- a/src/mni_7t_dicom_to_bids/dictionary.py
+++ b/src/mni_7t_dicom_to_bids/dictionary.py
@@ -5,65 +5,75 @@
 # The value is a DICOM series description or a list of DICOM series descriptions
 # for that BIDS data type and acquisition.
 # Current series: MPN, MICA-lab, JBL.
+# last update: August 5 2026 by RRC.
 
+# Reordered list based on the acquisition
+# Suffixed based on the BIDS specification v1.11.1 schema files:
+# https://github.com/bids-standard/bids-specification/blob/master/src/schema/objects/suffixes.yaml
 bids_dicom_mappings: dict[str, dict[str, list[str] | str]] = {
     'anat': {
-        # FLAIR
+        # FLAIR 0.7mm isometric
         'FLAIR': [
             'anat-flair_acq-0*7iso_UPAdia',
             'anat-flair_acq-0*7mm_UPAdia',
             'anat-flair_acq-0*7iso_dev3_5SD_UP',
         ],
 
-        # UNIT1
-        'acq-07mm_UNIT1'      : '*anat-T1w_acq-mp2rage_0*7mm_CSptx_UNI_Images',
-        'desc-denoised_UNIT1' : '*anat-T1w_acq-mp2rage_0*7mm_CSptx_UNI-DEN',
-
-        # T1
-        'acq-07mm_T1map' : '*anat-T1w_acq-mp2rage_0*7mm_CSptx_T1_Images',
-        'T1w'   : [
+        # T1w/MPRAGE - DEFAULT MPN acquisition. 0.8mm isometric
+        'acq-mprage08CS_T1w'   : [
             'anat-T1w_acq_mprage_0*8mm_CSptx',
             'anat-T1w_acq_mprage_0*8mm_CSx_ND',
-            '*anat-T1w_acq-mprage_0*7mm_UP',
         ],
-
-        # T2
-        'acq-SWI_T2starw'                      : '*CLEAR-SWI_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-        'acq-romeo_T2starw'                    : '*Romeo_P_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-        'acq-romeo_rec-mask_T2starw'           : '*Romeo_Mask_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-        'acq-romeo_rec-unwrapped_T2starw'      : '*Romeo_B0_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-        'acq-aspire_T2starw': [
-            'Aspire_M_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-            'Aspire_P_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-            '*T2star_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-        ],
-        'acq-aspire_rec-echoCombined_T2starw'  : '*EchoCombined_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-        'acq-aspire_rec-echoCombinedSensitivityCorrected_T2starw':
-            '*sensitivity_corrected_mag_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
-        'T2map': '*T2Star_Images',
-        'acq-me_T2starw': '*anat-T2star_acq-me_gre_07mm*',
+        
+        # T1w/MPRAGE - other 0.7mm isometric
+        'acq-mprage07UP_T1w'   : '*anat-T1w_acq-mprage_0*7mm_UP',
 
         # 0.7mm MP2RAGE
-        'acq-07mm_inv-1_MP2RAGE': '*anat-T1w_acq-mp2rage_0*7mm_CSptx_INV1',
-        'acq-07mm_inv-2_MP2RAGE': '*anat-T1w_acq-mp2rage_0*7mm_CSptx_INV2',
+        'acq-mp2rage07CSptx_inv-1_MP2RAGE': '*anat-T1w_acq-mp2rage_0*7mm_CSptx_INV1',
+        'acq-mp2rage07CSptx_inv-2_MP2RAGE': '*anat-T1w_acq-mp2rage_0*7mm_CSptx_INV2',
+        'acq-mp2rage07CSptx_T1map' : '*anat-T1w_acq-mp2rage_0*7mm_CSptx_T1_Images',
+        'acq-mp2rage07CSptx_UNIT1'               : '*anat-T1w_acq-mp2rage_0*7mm_CSptx_UNI_Images',
+        'acq-mp2rage07CSptx_rec-denoised_UNIT1' : '*anat-T1w_acq-mp2rage_0*7mm_CSptx_UNI-DEN',
 
         # 0.5mm MP2RAGE
-        'acq-05mm_inv-1_MP2RAGE': '*anat-T1w_acq-mp2rage_05mm_UP*_INV1*',
-        'acq-05mm_inv-2_MP2RAGE': '*anat-T1w_acq-mp2rage_05mm_UP*_INV2*',
-        'acq-05mm_T1map': '*anat-T1w_acq-mp2rage_05mm_UP*_T1_Images*',
-        'acq-05mm_UNIT1': '*anat-T1w_acq-mp2rage_05mm_UP*_UNI_Images*',
+        'acq-mp2rage05UP_inv-1_MP2RAGE': '*anat-T1w_acq-mp2rage_05mm_UP*_INV1*',
+        'acq-mp2rage05UP_inv-2_MP2RAGE': '*anat-T1w_acq-mp2rage_05mm_UP*_INV2*',
+        'acq-mp2rage05UP_T1map': '*anat-T1w_acq-mp2rage_05mm_UP*_T1_Images*',
+        'acq-mp2rage05UP_UNIT1': '*anat-T1w_acq-mp2rage_05mm_UP*_UNI_Images*',
 
         # High-resolution MP2RAGE - CSTFL - Compressed sensing turboflash
         'acq-cstfl_inv-1_MP2RAGE': '*cstfl-mp2rage-05mm_INV1',
         'acq-cstfl_inv-2_MP2RAGE': '*cstfl-mp2rage-05mm_INV2',
         'acq-cstfl_T1map': '*cstfl-mp2rage-05mm_T1_Images',
         'acq-cstfl_UNIT1': '*cstfl-mp2rage-05mm_UNI_Images',
-        'acq-cstflDenoised_UNIT1': '*cstfl-mp2rage-05mm_UNI-DEN',
+        'acq-cstfl_rec-denoised_UNIT1': '*cstfl-mp2rage-05mm_UNI-DEN',
 
-        # MTW
+        # T2starw: ASPIRE/ROMEO Multi echo gradient recalled echo (MEGRE) | MPN DEFAULT acquisition
+        # ASPIRE: Adaptive Combined Phase Imaging
+        # ROMEO: (reconstruction) Rapid Open-source MRI Phase Estimation and Optimization
+        'acq-megre07_rec-CLEARSWI_T2starw'          : '*CLEAR-SWI_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+        'acq-megre07_rec-ASPIRE_MEGRE': [
+            'Aspire_M_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+            'Aspire_P_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+        ],
+        'acq-megre07_rec-ASPIRE_T2starw': '*T2star_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+        'acq-megre07_rec-ASPIRE_desc-EchoCombined_T2starw' : '*EchoCombined_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+        'acq-megre07_rec-ASPIRE_desc-EchoCombinedSensCorr_T2starw':
+            '*sensitivity_corrected_mag_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+        'T2map': '*T2Star_Images',
+        'acq-megre07_rec-ROMEO_T2starw'         : '*Romeo_P_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+        'acq-megre07_rec-ROMEO_desc-mask_T2starw'          : '*Romeo_Mask_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+        'acq-megre07_rec-ROMEO_desc-unwrapped_T2starw'     : '*Romeo_B0_anat-T2star_acq-me_gre_0*7iso_ASPIRE',
+
+        # T2starw: MEGRE multi echo gradient recalled echo | previous acquisition
+        'acq-me_T2starw': '*anat-T2star_acq-me_gre_07mm*',
+
+        # MTW |  MPN DEFAULT acquisition
         'acq-mtw_T1w'        : '*anat-mtw_acq-T1w_07mm',
         'acq-mtw_mt-on_MTR'  : '*anat-mtw_acq-MTON_07mm',
         'acq-mtw_mt-off_MTR' : '*anat-mtw_acq-MTOFF_07mm',
+
+        # T1w from the previous MTR acquisition
         'acq-MTR_T1w': '*_T1W',
 
         # NEUROMELANIN
@@ -71,12 +81,11 @@ bids_dicom_mappings: dict[str, dict[str, list[str] | str]] = {
             'anat-nm_acq-MTboost_sag_0.55mm',
             'CR_tfl_MTboost_sag7deg_0.55mm',
         ],
-
         # ANGIO
-        'angio'         : '*anat-angio_acq-tof_03mm_inplane',
-        'acq-cor_angio' : '*anat-angio_acq-tof_03mm_inplane_MIP_COR',
-        'acq-sag_angio' : '*anat-angio_acq-tof_03mm_inplane_MIP_SAG',
-        'acq-tra_angio' : '*anat-angio_acq-tof_03mm_inplane_MIP_TRA',
+        'acq-tof03_angio'         : '*anat-angio_acq-tof_03mm_inplane',
+        'acq-tof03_rec-cor_angio' : '*anat-angio_acq-tof_03mm_inplane_MIP_COR',
+        'acq-tof03_rec-sag_angio' : '*anat-angio_acq-tof_03mm_inplane_MIP_SAG',
+        'acq-tof03_rec-tra_angio' : '*anat-angio_acq-tof_03mm_inplane_MIP_TRA',
     },
     'dwi': {
         # B0
@@ -185,21 +194,43 @@ ignored_dicom_series_suffixes: list[str] = [
 ]
 
 # The order in which the BIDS entities should appear in a BIDS file name.
-# This order is taken from the BIDS specification entity table:
-# https://bids-specification.readthedocs.io/en/stable/appendices/entity-table.html
+# This order is taken from the BIDS specifications v1.11.1 Feb 19, 2026 schema files:
+#   Entities order: https://github.com/bids-standard/bids-specification/blob/master/src/schema/rules/entities.yaml
+#   Entities definition: https://github.com/bids-standard/bids-specification/blob/master/src/schema/objects/entities.yaml
 bids_label_order = [
-    'sub',
-    'ses',
-    'task',
-    'acq',
-    'ce',
-    'rec',
-    'inv',
-    'mt',
-    'dir',
-    'run',
-    'echo',
-    'part',
-    'chunk',
-    'desc',  # Note that 'desc' is not in the entity table.
+    'sub', 
+    'tpl', 
+    'ses', 
+    'cohort', 
+    'sample', 
+    'task', 
+    'tracksys', 
+    'acq', 
+    'nuc', 
+    'voi', 
+    'ce', 
+    'trc', 
+    'stain', 
+    'rec', 
+    'dir', 
+    'run', 
+    'mod', 
+    'echo', 
+    'flip', 
+    'inv', 
+    'mt', 
+    'part', 
+    'proc', 
+    'hemi', 
+    'space', 
+    'split', 
+    'recording', 
+    'chunk', 
+    'atlas', 
+    'seg', 
+    'scale', 
+    'res', 
+    'den', 
+    'label', 
+    'desc' # There is a current convention to keep description to be the last entity.
 ]


### PR DESCRIPTION
## Summary

This pull request updates the DICOM-to-BIDS dictionary and accompanying documentation following the discussion in Issue [#15](https://github.com/BIC-MNI/mni-7t-dicom-to-bids/issues/15) The proposed changes improve BIDS naming consistency, align with the current BIDS specification (v1.11.1), and reduce potential filename parsing issues in downstream tools such as `pyBIDS`, while recognizing that some limitations are inherent to the acquisition protocols.
This PR primarily addresses items **5**, **6**, and **7** from Issue #15.

The changes include:

- Updating BIDS filename mappings in dictionary.py.
- Synchronizing the naming conventions documented in the top-level README.md.
- Reorganizing and documenting the anatomical acquisition mappings to improve readability and maintainability.
- Updating the BIDS entity ordering to match the current BIDS specification (v1.11.1).

These changes modify filename generation and may affect downstream functionality of the dicom to BIDS convertor (e.g., string matching, file organization into modality-specific directories, and other processing pipelines). Thorough validation of the generated outputs is therefore recommended before including these changes in a major release.

Fixes part of #15.

docs document: [MPN_BIDS-naming_changes](https://docs.google.com/document/d/1sOhuBn8VR2jcHNOMaj3zMDh8Z37NFlE3Oz9g_m4_9o0/edit?tab=t.0)